### PR TITLE
Use bulk api instead of home made threads

### DIFF
--- a/samples/data.csv
+++ b/samples/data.csv
@@ -3,3 +3,13 @@ MOZA,Moshe,Zada
 MICHO,Michelle,Obama
 DONTRA,Donald,Trump
 HILLCLI,Hillary,Clinton
+HILLCLI,Hillary,Clinton
+HILLCLI,Hillary,Clinton
+HILLCLI,Hillary,Clinton
+HILLCLI,Hillary,Clinton
+HILLCLI,Hillary,Clinton
+HILLCLI,Hillary,Clinton
+HILLCLI,Hillary,Clinton
+HILLCLI,Hillary,Clinton
+HILLCLI,Hillary,Clinton
+a,b,c

--- a/test/test_csv.py
+++ b/test/test_csv.py
@@ -4,7 +4,7 @@ import mock
 
 
 def invoke(*args, **kwargs):
-    content = """id,first,last\nMOZA,Moshe,Zada\nMICHO,Michelle,Obama"""
+    content = """id,first,last\nMOZA,Moshe,Zada\nMICHO,Michelle,Obama\na,b,c\nf,g,h"""
     runner = CliRunner()
     with runner.isolated_filesystem():
         with open('sample.csv', 'w') as f:
@@ -14,16 +14,12 @@ def invoke(*args, **kwargs):
 
 @mock.patch('elasticsearch_loader.single_bulk_to_es')
 def test_should_iterate_over_csv(bulk):
-        result = invoke(cli, ['--index=index', '--type=type', 'csv', 'sample.csv'], catch_exceptions=False)
-        assert result.exit_code == 0
-        assert filter(None, bulk.call_args[0][0]) == ({'first': 'Moshe', 'id': 'MOZA', 'last': 'Zada'}, {'first': 'Michelle', 'id': 'MICHO', 'last': 'Obama'})
-
-
-@mock.patch('elasticsearch_loader.single_bulk_to_es')
-def test_should_iterate_over_csv_concurrency_1(bulk):
-        result = invoke(cli, ['--concurrency=1', '--index=index', '--type=type', 'csv', 'sample.csv'], catch_exceptions=False)
-        assert result.exit_code == 0
-        assert filter(None, bulk.call_args[0][0]) == ({'first': 'Moshe', 'id': 'MOZA', 'last': 'Zada'}, {'first': 'Michelle', 'id': 'MICHO', 'last': 'Obama'})
+    result = invoke(cli, ['--index=index', '--type=type', 'csv', 'sample.csv'], catch_exceptions=False)
+    assert result.exit_code == 0
+    assert filter(None, bulk.call_args[0][0]) == ({'first': 'Moshe', 'id': 'MOZA', 'last': 'Zada'},
+                                                  {'first': 'Michelle', 'id': 'MICHO', 'last': 'Obama'},
+                                                  {'first': 'b', 'id': 'a', 'last': 'c'},
+                                                  {'first': 'g', 'id': 'f', 'last': 'h'})
 
 
 @mock.patch('elasticsearch_loader.single_bulk_to_es')
@@ -31,4 +27,4 @@ def test_should_iterate_over_csv_bulk_size_1(bulk):
         result = invoke(cli, ['--bulk-size=1', '--index=index', '--type=type', 'csv', 'sample.csv'], catch_exceptions=False)
         assert result.exit_code == 0
         assert bulk.call_count == 2
-        assert filter(None, bulk.call_args[0][0]) == ({'first': 'Michelle', 'id': 'MICHO', 'last': 'Obama'},)
+        assert filter(None, bulk.call_args[0][0]) == ({'first': 'g', 'id': 'f', 'last': 'h'},)

--- a/test/test_json.py
+++ b/test/test_json.py
@@ -5,7 +5,9 @@ import mock
 
 def invoke(*args, **kwargs):
     content = """[{"id": "MOZA", "first": "Moshe", "last": "Zada"},
-                     {"id": "MICHO", "first": "Michelle", "last": "Obama"}]"""
+                     {"id": "MICHO", "first": "Michelle", "last": "Obama"},
+                     {"id": "a", "first": "b", "last": "c"},
+                     {"id": "d", "first": "e", "last": "f"}]"""
     runner = CliRunner()
     with runner.isolated_filesystem():
         with open('sample.json', 'w') as f:
@@ -17,14 +19,10 @@ def invoke(*args, **kwargs):
 def test_should_iterate_over_json(bulk):
         result = invoke(cli, ['--index=index', '--type=type', 'json', 'sample.json'], catch_exceptions=False)
         assert result.exit_code == 0
-        assert filter(None, bulk.call_args[0][0]) == ({'first': 'Moshe', 'id': 'MOZA', 'last': 'Zada'}, {'first': 'Michelle', 'id': 'MICHO', 'last': 'Obama'})
-
-
-@mock.patch('elasticsearch_loader.single_bulk_to_es')
-def test_should_iterate_over_json_concurrency_1(bulk):
-        result = invoke(cli, ['--concurrency=1', '--index=index', '--type=type', 'json', 'sample.json'], catch_exceptions=False)
-        assert result.exit_code == 0
-        assert filter(None, bulk.call_args[0][0]) == ({'first': 'Moshe', 'id': 'MOZA', 'last': 'Zada'}, {'first': 'Michelle', 'id': 'MICHO', 'last': 'Obama'})
+        assert filter(None, bulk.call_args[0][0]) == ({'first': 'Moshe', 'id': 'MOZA', 'last': 'Zada'},
+                                                      {'first': 'Michelle', 'id': 'MICHO', 'last': 'Obama'},
+                                                      {'first': 'b', 'id': 'a', 'last': 'c'},
+                                                      {'first': 'e', 'id': 'd', 'last': 'f'})
 
 
 @mock.patch('elasticsearch_loader.single_bulk_to_es')
@@ -32,4 +30,4 @@ def test_should_iterate_over_json_bulk_size_1(bulk):
         result = invoke(cli, ['--bulk-size=1', '--index=index', '--type=type', 'json', 'sample.json'], catch_exceptions=False)
         assert result.exit_code == 0
         assert bulk.call_count == 2
-        assert filter(None, bulk.call_args[0][0]) == ({'first': 'Michelle', 'id': 'MICHO', 'last': 'Obama'},)
+        assert filter(None, bulk.call_args[0][0]) == (({'first': 'e', 'id': 'd', 'last': 'f'},))

--- a/test/test_jsonlines.py
+++ b/test/test_jsonlines.py
@@ -4,7 +4,10 @@ import mock
 
 
 def invoke(*args, **kwargs):
-    content = """{"id": "MOZA", "first": "Moshe", "last": "Zada"}\n{"id": "MICHO", "first": "Michelle", "last": "Obama"}"""
+    content = """{"id": "MOZA", "first": "Moshe", "last": "Zada"}
+                     {"id": "MICHO", "first": "Michelle", "last": "Obama"}
+                     {"id": "a", "first": "b", "last": "c"}
+                     {"id": "d", "first": "e", "last": "f"}"""
     runner = CliRunner()
     with runner.isolated_filesystem():
         with open('sample.json', 'w') as f:
@@ -16,14 +19,10 @@ def invoke(*args, **kwargs):
 def test_should_iterate_over_json(bulk):
         result = invoke(cli, ['--index=index', '--type=type', 'json', 'sample.json', '--json-lines'], catch_exceptions=False)
         assert result.exit_code == 0
-        assert filter(None, bulk.call_args[0][0]) == ({'first': 'Moshe', 'id': 'MOZA', 'last': 'Zada'}, {'first': 'Michelle', 'id': 'MICHO', 'last': 'Obama'})
-
-
-@mock.patch('elasticsearch_loader.single_bulk_to_es')
-def test_should_iterate_over_json_concurrency_1(bulk):
-        result = invoke(cli, ['--concurrency=1', '--index=index', '--type=type', 'json', 'sample.json', '--json-lines'], catch_exceptions=False)
-        assert result.exit_code == 0
-        assert filter(None, bulk.call_args[0][0]) == ({'first': 'Moshe', 'id': 'MOZA', 'last': 'Zada'}, {'first': 'Michelle', 'id': 'MICHO', 'last': 'Obama'})
+        assert filter(None, bulk.call_args[0][0]) == ({'first': 'Moshe', 'id': 'MOZA', 'last': 'Zada'},
+                                                      {'first': 'Michelle', 'id': 'MICHO', 'last': 'Obama'},
+                                                      {'first': 'b', 'id': 'a', 'last': 'c'},
+                                                      {'first': 'e', 'id': 'd', 'last': 'f'})
 
 
 @mock.patch('elasticsearch_loader.single_bulk_to_es')
@@ -31,4 +30,4 @@ def test_should_iterate_over_json_bulk_size_1(bulk):
         result = invoke(cli, ['--bulk-size=1', '--index=index', '--type=type', 'json', 'sample.json', '--json-lines'], catch_exceptions=False)
         assert result.exit_code == 0
         assert bulk.call_count == 2
-        assert filter(None, bulk.call_args[0][0]) == ({'first': 'Michelle', 'id': 'MICHO', 'last': 'Obama'},)
+        assert filter(None, bulk.call_args[0][0]) == (({'first': 'e', 'id': 'd', 'last': 'f'},))


### PR DESCRIPTION
Closes #13 (Use `--progress` in order to enable progress bar)
Closes #12 (ESL checks if index exists before creating it, update if needed)

