### PR TITLE
Python2's stdlib csv module doesn't support unicode, get import the N…

### DIFF
--- a/elasticsearch_loader/__init__.py
+++ b/elasticsearch_loader/__init__.py
@@ -8,7 +8,8 @@ from click_stream import Stream
 from click_conf import conf
 from itertools import chain
 from datetime import datetime
-import csv
+#import csv
+import unicodecsv as csv
 import click
 
 from .parsers import json, parquet
@@ -93,7 +94,7 @@ def cli(ctx, **opts):
 @click.option('--delimiter', default=',', type=str, help='Default ,')
 @click.pass_context
 def _csv(ctx, files, delimiter):
-    lines = chain(*(csv.DictReader(x, delimiter=str(delimiter)) for x in files))
+    lines = chain(*(csv.DictReader(x, encoding='utf-8', delimiter=str(delimiter)) for x in files))
     log('info', 'Loading into ElasticSearch')
     load(lines, ctx.obj)
 

--- a/elasticsearch_loader/iter.py
+++ b/elasticsearch_loader/iter.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 try:
     from itertools import izip_longest as zip_longest
 except ImportError:

--- a/elasticsearch_loader/parsers.py
+++ b/elasticsearch_loader/parsers.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 try:
     import ujson as json
 except ImportError:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ click
 futures
 click-stream
 click-conf
+unicodecsv

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         'elasticsearch',
         'click==6.7',
         'click-stream==0.0.6',
-        'futures'
+        'futures',
         'unicodecsv'
     ],
     tests_require=[

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ setup(
         'click',
         'click-conf',
         'click-stream==0.0.5',
-        'futures'
+        'futures',
+        'unicodecsv'
     ],
     tests_require=[
         'pytest',


### PR DESCRIPTION
…ON-ANSI encoded csv import failed. so use unicodecsv as drop-in replacement