### PR TITLE
add option '--as-child' /  '--with-retry'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# Visual Studio Code settings
+.vscode

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Options:
   --as-child                      Insert _parent, _routing field, the value is 
                                   same as _id. Note: must specify --id-field
                                   explicitly
+  --with-retry                    Retry if ES bulk insertion failed
   --index-settings-file FILENAME  Specify path to json file containing index
                                   mapping and settings, creates index if
                                   missing

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ Options:
   --type TEXT                     Docs type  [required]
   --id-field TEXT                 Specify field name that be used as document
                                   id
+  --as-child                      Insert _parent, _routing field, the value is 
+                                  same as _id. Note: must specify --id-field
+                                  explicitly
   --index-settings-file FILENAME  Specify path to json file containing index
                                   mapping and settings, creates index if
                                   missing

--- a/elasticsearch_loader/__init__.py
+++ b/elasticsearch_loader/__init__.py
@@ -10,14 +10,38 @@ from itertools import chain
 from datetime import datetime
 import csv
 import click
+import time
 
 from .parsers import json, parquet
 from .iter import grouper, bulk_builder, json_lines_iter
 
 
-def single_bulk_to_es(bulk, config):
+def single_bulk_to_es(bulk, config, attempt_retry):
     bulk = bulk_builder(bulk, config)
-    helpers.bulk(config['es_conn'], bulk, chunk_size=config['bulk_size'])
+
+    max_attempt = 1
+    if attempt_retry:
+        max_attempt += 3
+    
+    for attempt in range(1, max_attempt+1):
+        try:
+            helpers.bulk(config['es_conn'], bulk, chunk_size=config['bulk_size'])
+        except Exception as e:
+            if attempt < max_attempt:
+                wait_seconds = attempt*3
+                log('warn', 'attempt [%s/%s] got exception, will retry after %s seconds' % (attempt,max_attempt,wait_seconds) )
+                time.sleep(wait_seconds)
+                continue
+
+            log('error', 'attempt [%s/%s] got exception, it is a permanent data loss, no retry any more' % (attempt,max_attempt) )
+            raise e
+
+        if attempt > 1:
+            log('info', 'attempt [%s/%s] succeed. we just get recovered from previous error' % (attempt,max_attempt) )
+
+        # completed succesfully
+        break
+
 
 
 def load(lines, config):
@@ -27,7 +51,7 @@ def load(lines, config):
     with click.progressbar(bulks) as pbar:
         for i, bulk in enumerate(pbar):
             try:
-                single_bulk_to_es(bulk, config)
+                single_bulk_to_es(bulk, config, config['with_retry'])
             except Exception as e:
                 log('warn', 'Chunk {i} got exception ({e}) while processing'.format(e=e, i=i))
 
@@ -55,6 +79,7 @@ def log(sevirity, msg):
 @click.option('--type', help='Docs type', required=True)
 @click.option('--id-field', help='Specify field name that be used as document id')
 @click.option('--as-child', default=False, is_flag=True, help='Insert _parent, _routing field, the value is same as _id')
+@click.option('--with-retry', default=False, is_flag=True, help='Retry if ES bulk insertion failed')
 @click.option('--index-settings-file', type=click.File('rb'), help='Specify path to json file containing index mapping and settings, creates index if missing')
 @click.pass_context
 def cli(ctx, **opts):
@@ -118,6 +143,7 @@ def _parquet(ctx, files):
     if not parquet:
         raise SystemExit("parquet module not found, please install manually")
     lines = chain(*(parquet.DictReader(x) for x in files))
+    lines = (dict_convert_binary_to_string(x) for x in lines)
     log('info', 'Loading into ElasticSearch')
     load(lines, ctx.obj)
 
@@ -127,11 +153,16 @@ def load_plugins():
         log('info', 'loading %s' % plugin.module_name)
         plugin.resolve()(cli)
 
-
 def main():
     load_plugins()
     cli()
 
+def dict_convert_binary_to_string(m):
+    for k,v in m.items():
+        if isinstance(v, bytes):
+            m[k] = v.decode()
+
+    return m
 
 if __name__ == '__main__':
     main()

--- a/elasticsearch_loader/__init__.py
+++ b/elasticsearch_loader/__init__.py
@@ -54,6 +54,7 @@ def log(sevirity, msg):
 @click.option('--progress', default=False, is_flag=True, help='Enable progress bar - NOTICE: in order to show progress the entire input should be collected and can consume more memory than without progress bar')
 @click.option('--type', help='Docs type', required=True)
 @click.option('--id-field', help='Specify field name that be used as document id')
+@click.option('--as-child', default=False, is_flag=True, help='Insert _parent, _routing field, the value is same as _id')
 @click.option('--index-settings-file', type=click.File('rb'), help='Specify path to json file containing index mapping and settings, creates index if missing')
 @click.pass_context
 def cli(ctx, **opts):

--- a/elasticsearch_loader/iter.py
+++ b/elasticsearch_loader/iter.py
@@ -17,8 +17,14 @@ def bulk_builder(bulk, config):
         body = {'_index': config['index'],
                 '_type': config['type'],
                 '_source': item}
+                
         if config['id_field']:
             body['_id'] = item[config['id_field']]
+            
+            if config['as_child']:
+                body['_parent'] = body['_id']
+                body['_routing'] = body['_id']
+            
         yield body
 
 

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ except Exception:
 
 setup(
     name='elasticsearch-loader',
-    author='Moshe Zada',
-    version='0.2.2',
+    author='Moshe Zada (modified by Alex Zhu)',
+    version='0.2.5',
     packages=['elasticsearch_loader'],
     keywords=['elastic', 'elasticsearch', 'csv', 'json', 'parquet', 'bulk', 'loader'],
     url='https://github.com/Moshe/elasticsearch_loader',


### PR DESCRIPTION
CHANGES:
- add option '--as-child', so it can insert data into child type of a 'parent-child' model
- add option '--with-retry'. ES's builtin retry only occur while server returns error 429. This retry is more general.
- support binary field in parquet file. By default, impala generated parquet use binary bytes to store STRING field.

NOTE:
do not need to merge 'setup.py'.

OTHERS:
This ETL tool is awesome. It do help me a lot!