### PR TITLE
add option '--update' for merging and updating.

### DIFF
--- a/elasticsearch_loader/__init__.py
+++ b/elasticsearch_loader/__init__.py
@@ -75,6 +75,7 @@ def log(sevirity, msg):
 @click.option('--http-auth', help='Provide username and password for basic auth in the format of username:password')
 @click.option('--index', help='Destination index name', required=True)
 @click.option('--delete', default=False, is_flag=True, help='Delete index before import? (default false)')
+@click.option('--update', default=False, is_flag=True, help='Merge and update existing doc instead of overwrite')
 @click.option('--progress', default=False, is_flag=True, help='Enable progress bar - NOTICE: in order to show progress the entire input should be collected and can consume more memory than without progress bar')
 @click.option('--type', help='Docs type', required=True)
 @click.option('--id-field', help='Specify field name that be used as document id')

--- a/elasticsearch_loader/iter.py
+++ b/elasticsearch_loader/iter.py
@@ -25,6 +25,12 @@ def bulk_builder(bulk, config):
                 body['_parent'] = body['_id']
                 body['_routing'] = body['_id']
             
+        if config['update']:
+            # default _op_type is 'index', which will overwrites existing doc
+            body['_op_type'] = 'update' 
+            body['doc'] = item
+            del body['_source']
+            
         yield body
 
 


### PR DESCRIPTION
if an existing doc has 3 fields, and we are now loading a target file with 1 fields, the behaviors are:

 - without '--update', the final doc only have 1 field which comes from target
 - with '--update', the final doc still have 3 fields, with the target field updated.

btw: the setup.py should add a dependecy 'click_conf'  ( click-conf renamed?）