### PR TITLE
Add option --parse-types to 'csv' command to discover CSV column data types

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     license='',
     long_description=long_description,
     description='A pythonic tool for batch loading data files (json, parquet, csv, tsv) into ElasticSearch',
-    install_requires=['elasticsearch>=6', 'click==6.7', 'click-stream', 'click-conf'] + extras,
+    install_requires=['elasticsearch>=6', 'click==6.7', 'click-stream', 'click-conf', 'enum34'] + extras,
     extras_require={
         'parquet': ['parquet'],
         'redis': ['esl-redis'],


### PR DESCRIPTION
Add option `--parse-types` to `csv` command to attempt discovering data types of CSV columns. This allows dynamic mapping in elasticsearch to work for CSV files instead of using `string` for all fields.

The following test file was used:  [dataset.csv.zip](https://github.com/moshe/elasticsearch_loader/files/2991731/dataset.csv.zip)

