### PR TITLE
Suggestion: add universial new line mode

### DIFF
--- a/elasticsearch_loader/__init__.py
+++ b/elasticsearch_loader/__init__.py
@@ -123,7 +123,7 @@ def cli(ctx, **opts):
 
 
 @cli.command(name='csv')
-@click.argument('files', type=Stream(file_mode='r'), nargs=-1, required=True)
+@click.argument('files', type=Stream(file_mode='rU'), nargs=-1, required=True)
 @click.option('--delimiter', default=',', type=str, help='Default ,')
 @click.pass_context
 def _csv(ctx, files, delimiter):


### PR DESCRIPTION
To fix the possible following error: 
https://stackoverflow.com/questions/17315635/csv-new-line-character-seen-in-unquoted-field-error

This is a very common scenario when encountering multi-system csv file format variance