### PR TITLE
Upgrade to click8 dependencies. Drop support for python2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,11 @@ before_install:
 language: python
 env:
   matrix:
+    - PYTHON=3.7 ES=docker.elastic.co/elasticsearch/elasticsearch:8.1.2
     - PYTHON=3.7 ES=docker.elastic.co/elasticsearch/elasticsearch:7.1.1
-    - PYTHON=2.7 ES=docker.elastic.co/elasticsearch/elasticsearch:7.1.1
     - PYTHON=3.7 ES=docker.elastic.co/elasticsearch/elasticsearch:6.8.0
-    - PYTHON=2.7 ES=docker.elastic.co/elasticsearch/elasticsearch:6.8.0
     - PYTHON=3.7 ES=docker.elastic.co/elasticsearch/elasticsearch:5.6.16
-    - PYTHON=2.7 ES=docker.elastic.co/elasticsearch/elasticsearch:5.6.16
     - PYTHON=3.7 ES=elasticsearch:2.4.6-alpine
-    - PYTHON=2.7 ES=elasticsearch:2.4.6-alpine
 script:
   - docker-compose --version
   - docker-compose up --build --abort-on-container-exit

--- a/README.md
+++ b/README.md
@@ -19,10 +19,9 @@ In order to install plugin, simply run `pip install plugin-name`
 
 ### Test matrix
 
-| python / es | 5.6.16 | 6.8.0 | 7.1.1 |
-| ----------- | ----- | ----- | ----- |
-| 2.7         | V     | V     | V     |
-| 3.7         | V     | V     | V     |
+| python / es | 5.6.16 | 6.8.0 | 7.1.1 | 8.1.2 |
+| ----------- | ----- | ----- | ----- | ----- |
+| 3.7         | V     | V     | V     | V     |
 
 ### Installation
 

--- a/elasticsearch_loader/__init__.py
+++ b/elasticsearch_loader/__init__.py
@@ -93,7 +93,7 @@ def log(sevirity, msg):
 @click.pass_context
 def cli(ctx, **opts):
     ctx.obj = opts
-    es_opts = {x: y for x, y in opts.items() if x in ('timeout', 'use_ssl', 'ca_certs', 'verify_certs', 'http_auth')}
+    es_opts = {x: y for x, y in list(opts.items()) if x in ('timeout', 'use_ssl', 'ca_certs', 'verify_certs', 'http_auth')}
     ctx.obj['es_conn'] = Elasticsearch(opts['es_host'], **es_opts)
     if opts['delete']:
         try:
@@ -109,7 +109,7 @@ def cli(ctx, **opts):
             ctx.obj['es_conn'].indices.create(
                 index=opts['index'], body=json.load(opts['index_settings_file']))
     if ctx.invoked_subcommand is None:
-        commands = cli.commands.keys()
+        commands = list(cli.commands.keys())
         if ctx.default_map:
             default_command = ctx.default_map.get('default_command')
             if default_command:

--- a/elasticsearch_loader/iter.py
+++ b/elasticsearch_loader/iter.py
@@ -1,7 +1,4 @@
-try:
-    from itertools import zip_longest as zip_longest
-except ImportError:
-    from itertools import zip_longest
+from itertools import zip_longest as zip_longest
 
 from .parsers import json
 

--- a/elasticsearch_loader/iter.py
+++ b/elasticsearch_loader/iter.py
@@ -1,5 +1,5 @@
 try:
-    from itertools import izip_longest as zip_longest
+    from itertools import zip_longest as zip_longest
 except ImportError:
     from itertools import zip_longest
 
@@ -13,10 +13,10 @@ def grouper(iterable, n, fillvalue=None):
 
 
 def bulk_builder(bulk, config):
-    for item in filter(None, bulk):
+    for item in [_f for _f in bulk if _f]:
         source = item
         if config['keys']:
-            source = {x: y for x, y in item.items() if x in config['keys']}
+            source = {x: y for x, y in list(item.items()) if x in config['keys']}
 
         body = {'_index': config['index'],
                 '_type': config['type'],

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     license='',
     long_description=long_description,
     description='A pythonic tool for batch loading data files (json, parquet, csv, tsv) into ElasticSearch',
-    install_requires=['elasticsearch>=6', 'click==7.1.1', 'click-stream==0.0.10', 'click-conf'] + extras,
+    install_requires=['elasticsearch>=6', 'click>=8.0.0', 'click-stream==0.0.10', 'click-conf'] + extras,
     extras_require={
         'parquet': ['parquet'],
         'redis': ['esl-redis'],

--- a/test.py
+++ b/test.py
@@ -4,8 +4,8 @@
 import yaml
 from subprocess import check_call
 
-matrix = yaml.safe_load(file('./.travis.yml'))['env']['matrix']
+matrix = yaml.safe_load(open('./.travis.yml'))['env']['matrix']
 for case in matrix:
-    print "-" * 15 + case + "-" * 15
+    print("-" * 15 + case + "-" * 15)
     check_call("{} docker-compose rm -f".format(case), shell=True)
     check_call("{} docker-compose up --build --abort-on-container-exit".format(case), shell=True)

--- a/test/test_csv.py
+++ b/test/test_csv.py
@@ -21,21 +21,21 @@ def invoke(content, *args, **kwargs):
 
 @mock.patch('elasticsearch_loader.single_bulk_to_es')
 def test_should_iterate_over_csv(bulk):
-    content = u"""id,first,last\nMOZA,Moshe,Zada\nMICHO,Michelle,Obama\na,b,c\nf,g,א"""
+    content = """id,first,last\nMOZA,Moshe,Zada\nMICHO,Michelle,Obama\na,b,c\nf,g,א"""
     result = invoke(content, cli, ['--index=index', '--type=type', 'csv', 'sample.csv'], catch_exceptions=False)
     assert result.exit_code == 0
     assert [x for x in bulk.call_args[0][0] if x is not None] == [{'first': 'Moshe', 'id': 'MOZA', 'last': 'Zada'},
                                                                   {'first': 'Michelle', 'id': 'MICHO', 'last': 'Obama'},
                                                                   {'first': 'b', 'id': 'a', 'last': 'c'},
-                                                                  {'first': 'g', 'id': 'f', 'last': u'א'}]
+                                                                  {'first': 'g', 'id': 'f', 'last': 'א'}]
 
 
 @mock.patch('elasticsearch_loader.single_bulk_to_es')
 def test_should_iterate_over_tsv(bulk):
-    content = u"""id	first	last\nMOZA	Moshe	Zada\nMICHO	Michelle	Obama\na	b	c\nf	g	א"""
+    content = """id	first	last\nMOZA	Moshe	Zada\nMICHO	Michelle	Obama\na	b	c\nf	g	א"""
     result = invoke(content, cli, ['--index=index', '--type=type', 'csv', '--delimiter=\\t', 'sample.csv'], catch_exceptions=False)
     assert result.exit_code == 0
     assert [x for x in bulk.call_args[0][0] if x is not None] == [{'first': 'Moshe', 'id': 'MOZA', 'last': 'Zada'},
                                                                   {'first': 'Michelle', 'id': 'MICHO', 'last': 'Obama'},
                                                                   {'first': 'b', 'id': 'a', 'last': 'c'},
-                                                                  {'first': 'g', 'id': 'f', 'last': u'א'}]
+                                                                  {'first': 'g', 'id': 'f', 'last': 'א'}]


### PR DESCRIPTION
This upgrades the dependencies to use click v8.0.0+ as requested in this [issue](https://github.com/moshe/elasticsearch_loader/issues/99)

To do this support for python2 is dropped and syntactic changes to support python3 are made.