### PR TITLE
Resolve [_type] illegal argument exception

### DIFF
--- a/elasticsearch_loader/iter.py
+++ b/elasticsearch_loader/iter.py
@@ -16,7 +16,7 @@ def bulk_builder(bulk, config):
             source = {x: y for x, y in list(item.items()) if x in config['keys']}
 
         body = {'_index': config['index'],
-                '_type': config['type'],
+                # '_type': config['type'], ~ type is now deprecated in Elasticsearch > 7
                 '_source': source}
 
         if config['id_field']:


### PR DESCRIPTION
Current version of `elasticsearch_loader` passes `_type` iteratively during data indexing. As per Elastic's [announcement & overview on types](https://www.elastic.co/blog/moving-from-types-to-typeless-apis-in-elasticsearch-7-0), typeless APIs have been best practice since ES 6.0, and users who have upgraded to ES 8.0 will *no longer* be able to use _type.

Elastic 8.0 users attempting to use elasticsearch_loader will be met with the error `RequestError(400, 'illegal_argument_exception', 'Action/metadata line [1] contains an unknown parameter [_type]')` despite not passing --type as a CLI arg.

This edit resolves the issue painlessly